### PR TITLE
fix: fallback for crypto.subtle in insecure contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ const payment = new PaymentBuilder()
 const { payment: response, secret, verifyUrl } = await service.addPayment(payment);
 ```
 
+# Environment Support
+
+The SDK uses the Web Crypto API (`crypto.subtle`) when available and transparently falls back to pure-JS implementations ([`@noble/hashes`](https://github.com/paulmillr/noble-hashes), [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers)) when it is not. This matters for browsers in non-secure contexts — pages served over plain HTTP (e.g. self-hosted node platforms like Umbrel or Start9 on a LAN) — where `crypto.subtle` is undefined. Payment verification works the same in both cases.
+
+The only hard requirement is `crypto.getRandomValues`. It is available in all modern browsers (regardless of secure context) and Node.js 18+. In React Native it is missing by default — install [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values) and import it before the SDK:
+
+```js
+import 'react-native-get-random-values';
+```
+
 # Release
 
  - npm login

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "@branta-ops/branta",
-  "version": "3.1.1",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@branta-ops/branta",
-      "version": "3.1.1",
+      "version": "3.1.3",
       "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^20.0.0",
@@ -994,6 +998,30 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",
     "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/hashes": "^2.2.0"
   }
 }

--- a/src/classes/aesEncryption.ts
+++ b/src/classes/aesEncryption.ts
@@ -1,20 +1,6 @@
+import { aesGcmDecrypt, aesGcmEncrypt, getRandomBytes, hmacSha256, sha256 } from './cryptoProvider.js';
+
 type Bytes = Uint8Array<ArrayBuffer>;
-
-const subtle = (): SubtleCrypto => {
-  const c = (globalThis as { crypto?: Crypto }).crypto;
-  if (!c?.subtle) {
-    throw new Error('Web Crypto API is not available. See README for React Native polyfill instructions.');
-  }
-  return c.subtle;
-};
-
-const getRandomBytes = (length: number): Bytes => {
-  const c = (globalThis as { crypto?: Crypto }).crypto;
-  if (!c?.getRandomValues) {
-    throw new Error('Web Crypto API is not available. See README for React Native polyfill instructions.');
-  }
-  return c.getRandomValues(new Uint8Array(length));
-};
 
 const utf8Bytes = (text: string): Bytes => new TextEncoder().encode(text);
 
@@ -37,17 +23,6 @@ const fromBase64 = (value: string): Bytes => {
   return bytes;
 };
 
-const sha256 = async (bytes: Bytes): Promise<Bytes> => {
-  const hash = await subtle().digest('SHA-256', bytes);
-  return new Uint8Array(hash);
-};
-
-const hmacSha256 = async (keyBytes: Bytes, messageBytes: Bytes): Promise<Bytes> => {
-  const key = await subtle().importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
-  const signature = await subtle().sign('HMAC', key, messageBytes);
-  return new Uint8Array(signature);
-};
-
 export class AesEncryption {
   static async encrypt(value: string, secret: string, deterministicNonce = false): Promise<string> {
     try {
@@ -61,10 +36,7 @@ export class AesEncryption {
         iv = derived.slice(0, 12) as Bytes;
       }
 
-      const key = await subtle().importKey('raw', keyData, 'AES-GCM', false, ['encrypt']);
-      const encrypted = new Uint8Array(
-        await subtle().encrypt({ name: 'AES-GCM', iv, tagLength: 128 }, key, utf8Bytes(value)),
-      );
+      const encrypted = await aesGcmEncrypt(keyData, iv, utf8Bytes(value));
 
       const result = new Uint8Array(iv.length + encrypted.length);
       result.set(iv, 0);
@@ -95,10 +67,7 @@ export class AesEncryption {
       const iv = encryptedData.slice(0, 12) as Bytes;
       const ciphertextAndTag = encryptedData.slice(12) as Bytes;
 
-      const key = await subtle().importKey('raw', keyData, 'AES-GCM', false, ['decrypt']);
-      const plaintext = new Uint8Array(
-        await subtle().decrypt({ name: 'AES-GCM', iv, tagLength: 128 }, key, ciphertextAndTag),
-      );
+      const plaintext = await aesGcmDecrypt(keyData, iv, ciphertextAndTag);
 
       return utf8String(plaintext);
     } catch (e) {

--- a/src/classes/cryptoProvider.ts
+++ b/src/classes/cryptoProvider.ts
@@ -1,0 +1,54 @@
+import { gcm } from '@noble/ciphers/aes.js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+
+type Bytes = Uint8Array<ArrayBuffer>;
+
+// SubtleCrypto is only exposed in secure contexts (HTTPS or localhost). Pages
+// served over plain HTTP (e.g. self-hosted node UIs on Umbrel/Start9) have
+// `crypto.getRandomValues` but no `crypto.subtle`, so every primitive below
+// falls back to a pure-JS implementation from the audited @noble packages.
+const getSubtle = (): SubtleCrypto | undefined => (globalThis as { crypto?: Crypto }).crypto?.subtle;
+
+export const getRandomBytes = (length: number): Bytes => {
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (!c?.getRandomValues) {
+    throw new Error('crypto.getRandomValues is not available. See README for React Native polyfill instructions.');
+  }
+  return c.getRandomValues(new Uint8Array(length));
+};
+
+export const sha256 = async (bytes: Bytes): Promise<Bytes> => {
+  const subtle = getSubtle();
+  if (subtle) {
+    return new Uint8Array(await subtle.digest('SHA-256', bytes));
+  }
+  return nobleSha256(bytes) as Bytes;
+};
+
+export const hmacSha256 = async (keyBytes: Bytes, messageBytes: Bytes): Promise<Bytes> => {
+  const subtle = getSubtle();
+  if (subtle) {
+    const key = await subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    return new Uint8Array(await subtle.sign('HMAC', key, messageBytes));
+  }
+  return hmac(nobleSha256, keyBytes, messageBytes) as Bytes;
+};
+
+export const aesGcmEncrypt = async (keyData: Bytes, iv: Bytes, plaintext: Bytes): Promise<Bytes> => {
+  const subtle = getSubtle();
+  if (subtle) {
+    const key = await subtle.importKey('raw', keyData, 'AES-GCM', false, ['encrypt']);
+    return new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv, tagLength: 128 }, key, plaintext));
+  }
+  return gcm(keyData, iv).encrypt(plaintext) as Bytes;
+};
+
+export const aesGcmDecrypt = async (keyData: Bytes, iv: Bytes, ciphertextAndTag: Bytes): Promise<Bytes> => {
+  const subtle = getSubtle();
+  if (subtle) {
+    const key = await subtle.importKey('raw', keyData, 'AES-GCM', false, ['decrypt']);
+    return new Uint8Array(await subtle.decrypt({ name: 'AES-GCM', iv, tagLength: 128 }, key, ciphertextAndTag));
+  }
+  return gcm(keyData, iv).decrypt(ciphertextAndTag) as Bytes;
+};

--- a/src/extensions/brantaExtensions.ts
+++ b/src/extensions/brantaExtensions.ts
@@ -1,17 +1,10 @@
 import { BrantaClientOptions } from '../classes/brantaClientOptions.js';
+import { sha256 } from '../classes/cryptoProvider.js';
 import { BrantaServerBaseUrl, BrantaServerBaseUrls } from '../enums/brantaServerBaseUrl.js';
 import { DestinationType } from '../enums/destinationType.js';
 import { PrivacyMode } from '../enums/privacyMode.js';
 
 type Bytes = Uint8Array<ArrayBuffer>;
-
-const subtle = (): SubtleCrypto => {
-  const c = (globalThis as { crypto?: Crypto }).crypto;
-  if (!c?.subtle) {
-    throw new Error('Web Crypto API is not available. See README for React Native polyfill instructions.');
-  }
-  return c.subtle;
-};
 
 export function getUrl(server: BrantaServerBaseUrl): string {
   const url = BrantaServerBaseUrls[server];
@@ -69,7 +62,7 @@ export function getHashZkType(value: string): DestinationType | undefined {
 export async function toNormalizedHash(value: string): Promise<string> {
   const normalized = value.toLowerCase();
   const bytes = new TextEncoder().encode(normalized) as Bytes;
-  const hash = new Uint8Array(await subtle().digest('SHA-256', bytes));
+  const hash = await sha256(bytes);
   let hex = '';
   for (let i = 0; i < hash.length; i++) {
     hex += hash[i]!.toString(16).padStart(2, '0').toUpperCase();

--- a/src/v2/services/brantaClient.ts
+++ b/src/v2/services/brantaClient.ts
@@ -1,4 +1,5 @@
 import { BrantaClientOptions } from '../../classes/brantaClientOptions.js';
+import { hmacSha256 } from '../../classes/cryptoProvider.js';
 import { BrantaPaymentException } from '../../exceptions/brantaPaymentException.js';
 import { getApiKey, getBaseUrl, getHmacSecret } from '../../extensions/brantaExtensions.js';
 import { IBrantaClient } from '../interfaces/iBrantaClient.js';
@@ -7,19 +8,10 @@ import { paymentFromApi, paymentToApi } from './serialization.js';
 
 type Bytes = Uint8Array<ArrayBuffer>;
 
-const subtle = (): SubtleCrypto => {
-  const c = (globalThis as { crypto?: Crypto }).crypto;
-  if (!c?.subtle) {
-    throw new Error('Web Crypto API is not available. See README for React Native polyfill instructions.');
-  }
-  return c.subtle;
-};
-
 const utf8Bytes = (text: string): Bytes => new TextEncoder().encode(text);
 
 const hmacSha256Hex = async (keyBytes: Bytes, messageBytes: Bytes): Promise<string> => {
-  const key = await subtle().importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
-  const signature = new Uint8Array(await subtle().sign('HMAC', key, messageBytes));
+  const signature = await hmacSha256(keyBytes, messageBytes);
   let hex = '';
   for (let i = 0; i < signature.length; i++) hex += signature[i]!.toString(16).padStart(2, '0');
   return hex;

--- a/test/classes/cryptoProvider.test.ts
+++ b/test/classes/cryptoProvider.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { AesEncryption } from '../../src/classes/aesEncryption.js';
+import { aesGcmDecrypt, aesGcmEncrypt, getRandomBytes, hmacSha256, sha256 } from '../../src/classes/cryptoProvider.js';
+import { toNormalizedHash } from '../../src/extensions/brantaExtensions.js';
+
+const realCrypto = globalThis.crypto;
+
+// Simulates an insecure browser context (plain HTTP): `crypto.getRandomValues`
+// exists but `crypto.subtle` does not.
+const withoutSubtle = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const insecureCrypto = {
+    getRandomValues: realCrypto.getRandomValues.bind(realCrypto),
+  } as Crypto;
+  Object.defineProperty(globalThis, 'crypto', { value: insecureCrypto, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', { value: realCrypto, configurable: true });
+  }
+};
+
+const utf8 = (text: string) => new TextEncoder().encode(text) as Uint8Array<ArrayBuffer>;
+
+describe('cryptoProvider without crypto.subtle', () => {
+  test('sha256 fallback matches Web Crypto output', async () => {
+    const input = utf8('lnbc1pvjluezpp5qqqsyq');
+
+    const expected = await sha256(input);
+    const actual = await withoutSubtle(() => sha256(input));
+
+    expect(Array.from(actual)).toEqual(Array.from(expected));
+  });
+
+  test('hmacSha256 fallback matches Web Crypto output', async () => {
+    const key = utf8('secret-key');
+    const message = utf8('message-body');
+
+    const expected = await hmacSha256(key, message);
+    const actual = await withoutSubtle(() => hmacSha256(key, message));
+
+    expect(Array.from(actual)).toEqual(Array.from(expected));
+  });
+
+  test('aesGcm fallback round-trips and interoperates with Web Crypto', async () => {
+    const key = await sha256(utf8('12345'));
+    const iv = utf8('0123456789ab').slice(0, 12) as Uint8Array<ArrayBuffer>;
+    const plaintext = utf8('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+
+    const encryptedWithFallback = await withoutSubtle(() => aesGcmEncrypt(key, iv, plaintext));
+    const encryptedWithWebCrypto = await aesGcmEncrypt(key, iv, plaintext);
+
+    expect(Array.from(encryptedWithFallback)).toEqual(Array.from(encryptedWithWebCrypto));
+
+    const decryptedWithWebCrypto = await aesGcmDecrypt(key, iv, encryptedWithFallback);
+    const decryptedWithFallback = await withoutSubtle(() => aesGcmDecrypt(key, iv, encryptedWithWebCrypto));
+
+    expect(Array.from(decryptedWithWebCrypto)).toEqual(Array.from(plaintext));
+    expect(Array.from(decryptedWithFallback)).toEqual(Array.from(plaintext));
+  });
+
+  test('getRandomBytes works without crypto.subtle', async () => {
+    const bytes = await withoutSubtle(async () => getRandomBytes(12));
+
+    expect(bytes.length).toBe(12);
+  });
+
+  test('AesEncryption round-trips without crypto.subtle', async () => {
+    const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    const secret = '12345';
+
+    const decrypted = await withoutSubtle(async () => {
+      const encrypted = await AesEncryption.encrypt(address, secret);
+      return AesEncryption.decrypt(encrypted, secret);
+    });
+
+    expect(decrypted).toBe(address);
+  });
+
+  test('deterministic encryption produces identical output with and without crypto.subtle', async () => {
+    const invoice = 'lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq';
+    const key = await toNormalizedHash(invoice);
+
+    const withWebCrypto = await AesEncryption.encrypt(invoice, key, true);
+    const withFallback = await withoutSubtle(() => AesEncryption.encrypt(invoice, key, true));
+
+    expect(withFallback).toBe(withWebCrypto);
+  });
+
+  test('toNormalizedHash works without crypto.subtle', async () => {
+    const invoice = 'LNBC20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypq';
+
+    const expected = await toNormalizedHash(invoice);
+    const actual = await withoutSubtle(() => toNormalizedHash(invoice));
+
+    expect(actual).toBe(expected);
+    expect(actual).toMatch(/^[0-9A-F]{64}$/);
+  });
+});


### PR DESCRIPTION
Fixes #52

⚠️ Adds two new dependencies: `@noble/ciphers` and `@noble/hashes`

## Fix

- New `src/classes/cryptoProvider.ts` centralizes all crypto primitives: uses the Web Crypto API when `crypto.subtle` is available, and transparently falls back to pure-JS implementations from the audited, dependency-free `@noble/hashes` (SHA-256, HMAC) and `@noble/ciphers` (AES-GCM) packages when it is not.
- `aesEncryption.ts`, `brantaExtensions.ts`, and `brantaClient.ts` now route through the provider, removing three duplicated throwing `subtle()` helpers.
- The only remaining hard requirement is `crypto.getRandomValues`, which is available in insecure browser contexts and Node 18+ (missing only in unpolyfilled React Native).
- README gains an **Environment Support** section documenting this, including the React Native polyfill instructions the old error message referenced but which did not exist.

No public API change. `isSupported()` (suggestion 2 in the issue) is unnecessary since verification now works everywhere.

## Tests

New `test/classes/cryptoProvider.test.ts` simulates an insecure context (`globalThis.crypto` without `subtle`) and verifies:

- SHA-256, HMAC, and AES-GCM fallback output is byte-identical to Web Crypto output
- Encrypt/decrypt interop in both directions between the two paths
- Deterministic encryption produces identical lookup tokens regardless of path
- `toNormalizedHash` (the exact failing path from the issue) works without `subtle`